### PR TITLE
Add summary section to OctoAcme project management README

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,8 +1,11 @@
 # OctoAcme Project Management Docs README
 
 This README offers a directory of all core OctoAcme project management process docs.
+
 ---
+
 ## Directory of Documentation
+
 - [Project Management Overview](./octoacme-project-management-overview.md)
 - [Project Initiation Guide](./octoacme-project-initiation.md)
 - [Project Planning](./octoacme-project-planning.md)
@@ -11,6 +14,16 @@ This README offers a directory of all core OctoAcme project management process d
 - [Release & Deployment Guide](./octoacme-release-and-deployment.md)
 - [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
 - [Roles & Personas](./octoacme-roles-and-personas.md)
+
 ---
+
 ## Summary of OctoAcme Project Management Processes
-...
+
+OctoAcme’s project management framework is designed to provide clarity, consistency, and shared responsibility across cross-functional product teams. Core roles include Project Managers (delivery, schedules, and communication), Product Managers (priorities and outcomes), Developers (building and testing features), QA (ensuring acceptance), and stakeholders (providing direction and approvals). Projects are anchored by artifacts like project one-pagers, roadmaps, sprint backlogs, and risk registers, all maintained for transparency and guidance.
+
+Projects begin with a business-focused initiation phase—validating needs and defining success. Planning breaks down deliverables into shippable increments, aligns dependencies, and estimates effort. Execution is supported by project boards, structured pull request workflows with strict acceptance and testing requirements, and visible tracking of metrics. Quality assurance is integrated: automated tests, manual QA, and regular security checks maintain standards at every stage.
+
+Communication is structured: daily standups, weekly syncs, and milestone demos support alignment. Risks are managed proactively via a risk register, with escalation paths from the team to stakeholders as needed. Every release follows a standardized checklist, from pre-release validation to stakeholder announcements and incident playbooks for rollbacks.
+
+OctoAcme’s project management approach emphasizes collaboration, transparency, and continuous improvement. Each phase of the lifecycle—from initiation to release—is guided by defined roles, structured communication, and measurable quality gates. By combining agile workflows with strong governance, OctoAcme ensures that all deliverables meet stakeholder expectations and drive sustainable project success.
+


### PR DESCRIPTION
Adds a concluding summary to the docs/README.md file describing OctoAcme’s
project management workflow, communication practices, and QA approach.

Linked issue: #2
Reviewer: @gill001-Tre
